### PR TITLE
GitHub workflow to run tests and add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Steps To Reproduce
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Additional context
+
+Add any other context or screenshots about the bug here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Describe the feature
+
+A clear and concise description of what you want to happen.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+This PR closes #
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: TEST
+
+on:
+  push: {}
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.7.7
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Container
+        run: |
+          apt-get update && apt-get install -y postgresql-client python3-gdal
+          pip3 install --upgrade --no-cache-dir pip
+          pip3 install --upgrade --no-cache-dir pipenv
+
+      - name: Setup Environment
+        working-directory: example
+        run: |
+          pipenv install --dev
+          pipenv run ./manage.py migrate --noinput
+          pipenv run ./manage.py collectstatic --noinput
+
+      - name: Run Tests
+        working-directory: example
+        run: |
+          pipenv run pytest


### PR DESCRIPTION
This PR closes #30  and closes #29 

I've added **Issue Templates**, based on existing but more stripped down to really all we need. These include templates for:

- Bug
- Feature
- Pull Requests

I have also added a **workflow** to manage the setup and running of tests  on `push`. This will run for PRs and when merged into `master`.