### PR TITLE
chore(backend): removed calls to deprecated code

### DIFF
--- a/astrosat/models.py
+++ b/astrosat/models.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from astrosat.mixins import SingletonMixin
 

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -13,7 +13,7 @@ import os
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from astrosat.utils import DynamicSetting
 


### PR DESCRIPTION
changed `ugettext_lazy` to `gettext_lazy` b/c the former will be deprecated soon.

This PR closes #37

