### PR TITLE
feat(backend): added swagger_fake decorator

### DIFF
--- a/astrosat/decorators.py
+++ b/astrosat/decorators.py
@@ -41,3 +41,34 @@ def conditional_exception(conditional, exception):
         return _wrapper
 
     return _decorator
+
+
+def swagger_fake(fake_retval=None):
+    """
+    A decorator for a view that returns the provided value
+    if being run in the context of swagger schema generation;
+    (as per https://github.com/axnsan12/drf-yasg/issues/333#issuecomment-474883875)
+    this is intended to be applied to "get_queryset" and/or "get_object"
+    """
+    def _decorator(view_fn):
+
+        @functools.wraps(view_fn)
+        def _wrapper(*args, **kwargs):
+            if not args:
+                # if this decorator is applied to a CBV using "method_decorator",
+                # then view_fn will actually be an instance of functools.partial;
+                # I have to introspect it to get the view it was called w/
+                _self = view_fn.func.__self__
+            else:
+                # if this decorator is applied directly to a fn then,
+                # then the 1st argument will be the view it was called w/
+                _self = args[0]
+
+            if getattr(_self, "swagger_fake_view", False):
+                return fake_retval
+
+            return view_fn(*args, **kwargs)
+
+        return _wrapper
+
+    return _decorator

--- a/astrosat/decorators.py
+++ b/astrosat/decorators.py
@@ -51,7 +51,6 @@ def swagger_fake(fake_retval=None):
     this is intended to be applied to "get_queryset" and/or "get_object"
     """
     def _decorator(view_fn):
-
         @functools.wraps(view_fn)
         def _wrapper(*args, **kwargs):
             if not args:

--- a/astrosat/decorators.py
+++ b/astrosat/decorators.py
@@ -59,7 +59,7 @@ def swagger_fake(fake_retval=None):
                 # I have to introspect it to get the view it was called w/
                 _self = view_fn.func.__self__
             else:
-                # if this decorator is applied directly to a fn then,
+                # if this decorator is applied directly to a fn,
                 # then the 1st argument will be the view it was called w/
                 _self = args[0]
 


### PR DESCRIPTION
Added a decorator that can be applied to views to prevent swagger errors during schema generation.  

Certain views rely on logged-in users and/or actual kwargs being passed to the views; those aren't provided during swagger schema generation and so errors will occur.  

There is already code in several apps to stop further processing in those views (as per https://github.com/axnsan12/drf-yasg/issues/333#issuecomment-474883875).  But doing it via a central decorator will remove loads of code duplication.
