### PR TITLE
fix(backend): add slashless routers

### DIFF
--- a/astrosat/routers.py
+++ b/astrosat/routers.py
@@ -1,0 +1,24 @@
+from rest_framework.routers import DefaultRouter, SimpleRouter
+
+
+# Most clients append a slash to their requests.
+# Some older ones (edge) do not, or do this inconsistently.
+# DRF can handle this via the `trailing_slash` kwarg
+# (as per https://www.django-rest-framework.org/api-guide/routers/#api-guide)
+# However, this means that requests must use ALL or NONE trailing_slashes
+# The two classes below use clever regexes to cater for BOTH cases;
+# They should be used in app's "urls.py" whenever trailing_slashes might be an issue
+
+
+class SlashlessDefaultRouter(DefaultRouter):
+
+    def __init__(self, *args, **kwargs):
+        self.trailing_slash = '/?'
+        super().__init__(*args, **kwargs)
+
+
+class SlashlessSimpleRouter(SimpleRouter):
+
+    def __init__(self, *args, **kwargs):
+        self.trailing_slash = '/?'
+        super().__init__(*args, **kwargs)

--- a/astrosat/urls.py
+++ b/astrosat/urls.py
@@ -1,13 +1,13 @@
 from django.urls import include, path
-from rest_framework.routers import SimpleRouter
 
+from .routers import SlashlessSimpleRouter
 from .views import DatabaseLogRecordViewSet, create_log_records, ProxyS3View
 
 ##############
 # API routes #
 ##############
 
-api_router = SimpleRouter()
+api_router = SlashlessSimpleRouter()
 api_router.register(r"logs", DatabaseLogRecordViewSet)
 api_urlpatterns = [
     path("", include(api_router.urls)),


### PR DESCRIPTION
Use custom DRF Routers that can support requests with or without trailing slashes.


