### PR TITLE
feat(backend): export logs as CSV

### DIFF
--- a/astrosat/admin.py
+++ b/astrosat/admin.py
@@ -71,7 +71,7 @@ class IncludeExcludeListFilter(admin.SimpleListFilter):
         _lookup_val = params.get(self.lookup_kwarg) or []
         _lookup_val_isnull = params.get(self.lookup_kwarg_isnull)
         self.lookup_val = _lookup_val.split(",") if _lookup_val else []
-        self.lookup_val_isnull = _lookup_val_isnull == "True"
+        self.lookup_val_isnull = _lookup_val_isnull == str(True)
         self._model_admin = model_admin
 
     def lookups(self, request, model_admin):
@@ -113,7 +113,7 @@ class IncludeExcludeListFilter(admin.SimpleListFilter):
         if self.include_empty_choice:
             yield {
                 'selected': bool(self.lookup_val_isnull),
-                'query_string': changelist.get_query_string({self.lookup_kwarg_isnull: 'True'}, [self.lookup_kwarg]),
+                'query_string': changelist.get_query_string({self.lookup_kwarg_isnull: True}, [self.lookup_kwarg]),
                 'display': self._model_admin.get_empty_value_display(),
             }
 

--- a/astrosat/templates/astrosat/admin/include_exclude_filter.html
+++ b/astrosat/templates/astrosat/admin/include_exclude_filter.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+
+{# used by astrosat.admin.IncludeExcludeListFilter #}
+
+<h3>
+    {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
+</h3>
+<ul>
+    {% for choice in choices %}
+        <li {% if choice.selected %} class="selected" {% endif %}>
+            {% if not choice.include_query_string and not choice.exclude_query_string %}
+                <a href="{{ choice.query_string|iriencode }}">{{ choice.display }}</a>
+            {% elif choice.include_query_string and not choice.selected %}
+                <a href="{{ choice.include_query_string|iriencode }}" title="include {{choice.display}}">{{ choice.display }}</a>
+            {% elif choice.exclude_query_string and choice.selected %}
+                <a href="{{ choice.exclude_query_string|iriencode }}" title="exclude {{choice.display}}">{{ choice.display }}</a>
+            {% endif %}
+        </li>
+    {% endfor %}
+</ul>


### PR DESCRIPTION
Updated the `DatabaseLogRecordAdmin` to 1

1. allow it to export selected `DatabaseLogRecords` as CSV 
3. provide a richer (Include/Exclude) filter for m2m "tags"

A future PR should also provide a richer filter for "created" so that admins can more easily narrow down exactly which log_records they want to export.

May also want to tweak the way the log message is serialized in case it really is stringified JSON.

