### PR TITLE
feat(backend): Ability to specify log level in create_log_records

### DIFF
--- a/astrosat/utils/utils_logging.py
+++ b/astrosat/utils/utils_logging.py
@@ -49,7 +49,7 @@ class DatabaseLogHandler(logging.Handler):
                 lambda x: x[0],
                 [
                     DatabaseLogTag.objects.get_or_create(name=tag_name)
-                    for tag_name in getattr(record, "tags", [])
+                    for tag_name in getattr(record, "tags", []) or []
                 ],
             )
 

--- a/astrosat/views.py
+++ b/astrosat/views.py
@@ -274,10 +274,17 @@ def create_log_records(request):
         for i, record in enumerate(request.data):
             assert "content" in record, "Log Record must contain key 'content' of JSON to be logged"
 
-            logger.info(
+            log_level = record.get("level", "info")
+            if log_level in ["error", "fatal"]:
+                fn = logger.error
+            elif log_level in ["warning"]:
+                fn = logger.warning
+            else:
+                fn = logger.info
+            fn(
                 json.dumps(record['content']),
                 extra={
-                    "tags": record.get('tags'),
+                    "tags": record.get('tags', []),
                     "uuid": uuids[i]
                 }
             )

--- a/astrosat/views.py
+++ b/astrosat/views.py
@@ -284,7 +284,7 @@ def create_log_records(request):
             fn(
                 json.dumps(record['content']),
                 extra={
-                    "tags": record.get('tags', []),
+                    "tags": record.get('tags'),
                     "uuid": uuids[i]
                 }
             )


### PR DESCRIPTION
The `create_log_records` view can specify the logging level.  If no level is specified, it defaults to "info".  Also, added some code to handle the case where _no_ tags are included.


This PR closes #54


