### PR TITLE
feat(backend): Allow the `export_as_csv` fn for `DatabaesLogRecordAdmin` take an arbitrary bit of JSON as the record message.   

### DIFF
--- a/astrosat/admin/admin_logging.py
+++ b/astrosat/admin/admin_logging.py
@@ -6,6 +6,7 @@ from django.http import HttpResponse
 
 from astrosat.models import DatabaseLogTag, DatabaseLogRecord
 from astrosat.serializers import DatabaseLogRecordSerializer
+from astrosat.utils import flatten_dictionary
 
 from .admin_base import DeleteOnlyModelAdminBase
 from .admin_utils import DateRangeListFilter, IncludeExcludeListFilter, get_clickable_m2m_list_display
@@ -60,8 +61,9 @@ class DatabaseLogRecordAdmin(DeleteOnlyModelAdminBase, admin.ModelAdmin):
                 record[header] = record.pop(field)
             try:
                 json_message = json.loads(record["record.message"])
-                extra_headers.update(json_message.keys())
-                record.update(json_message)
+                flattened_json_message = flatten_dictionary(json_message, separator=" | ")
+                extra_headers.update(flattened_json_message.keys())
+                record.update(flattened_json_message)
             except json.JSONDecodeError:
                 pass
             data.append(record)

--- a/astrosat/utils/__init__.py
+++ b/astrosat/utils/__init__.py
@@ -9,4 +9,5 @@ from .utils_iterators import grouper, partition
 from .utils_logging import RestrictLogsByNameFilter, DatabaseLogHandler
 from .utils_profile import show_toolbar, profile, track_memory
 from .utils_serializers import ExcludableJSONSerializer
+from .utils_utils import flatten_dictionary
 from .utils_validators import validate_no_spaces, validate_reserved_words, validate_no_tags, validate_schema

--- a/astrosat/utils/utils_utils.py
+++ b/astrosat/utils/utils_utils.py
@@ -1,0 +1,15 @@
+def flatten_dictionary(dictionary, key="", separator="."):
+    """
+    Takes a nested dictionary and converts it to a 1D dictionary
+    (keys of nested branches are concatenated together using separator)
+    """
+
+    dictionary_items = []
+    for k, v in dictionary.items():
+        new_key = key + separator + k if key else k
+        if isinstance(v, dict):
+            dictionary_items.extend(
+                flatten_dictionary(v, key=new_key, separator=separator).items())
+        else:
+            dictionary_items.append((new_key, v))
+    return dict(dictionary_items)

--- a/example/example/tests/test_utils_utils.py
+++ b/example/example/tests/test_utils_utils.py
@@ -1,0 +1,10 @@
+import pytest
+
+from astrosat.utils import flatten_dictionary
+
+
+def test_flatten_dictionary():
+    test_dictionary = {"I": {"AM": {"A": {"NESTED": "DICTIONARY"}}}}
+    flattened_test_dictionary = flatten_dictionary(test_dictionary,
+                                                   separator="-")
+    assert flattened_test_dictionary == {"I-AM-A-NESTED": "DICTIONARY"}


### PR DESCRIPTION

In order to communicate w/ `logstash` in **orbis** the structure of the JSON that is being logged has changed.

There was existing code to provide a CSV dump of the logs via the Django Admin and that code assumed a specific (non-nested) JSON structure.  

This PR refactors the `export_as_csv` fn to cope w/ any JSON structure.