### PR TITLE
chore(backend): update default_auto_field on a per-app basis

### DIFF
--- a/astrosat/apps.py
+++ b/astrosat/apps.py
@@ -5,7 +5,9 @@ from .utils import DynamicSetting
 
 
 class AstrosatConfig(AppConfig):
+
     name = APP_NAME
+    default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self):
 


### PR DESCRIPTION
Rather than update `default_auto_field` globally (as I did w/ #65), explicitly specify `default_auto_field` on the "astrosat" app.  

This way I don't have to globally update `default_auto_field` to "django.db.models.BigAutoField"  in projects and run the risk of creating custom migrations for _other_ reusable apps that haven't yet upgraded to Django 3.2 (and therefore still use "django.db.models.AutoField").


