### PR TITLE
fix(backend): fixed remove_urlpatterns

### DIFF
--- a/astrosat/views.py
+++ b/astrosat/views.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import uuid
+from collections import defaultdict
 from itertools import chain, filterfalse, groupby
 from functools import reduce
 
@@ -305,11 +306,10 @@ def remove_urlpatterns(urlpatterns, pattern_names_to_remove):
     """
     # yapf: disable
 
-    urls_to_check = {
-        # split urlpatterns into patterns & resolvers
-        k: list(g)
-        for k, g in groupby(urlpatterns, key=type)
-    }
+    # split urlpatterns into patterns & resolvers
+    urls_to_check = defaultdict(list)
+    for k, g in groupby(urlpatterns, key=type):
+        urls_to_check[k] += list(g)
 
     resolvers_to_keep = filterfalse(
         # note the double-looping to check patterns _w/in_ a resolver


### PR DESCRIPTION
I was inadvertently overwriting some of the resolvers/patterns in `remove_urlpatterns` which resulted in some of them not being returned from that fn when they should have been.


